### PR TITLE
[IR] ログインテストがコケていたのを修正

### DIFF
--- a/springboot/src/test/java/hello/LoginTests.java
+++ b/springboot/src/test/java/hello/LoginTests.java
@@ -43,26 +43,26 @@ public class LoginTests {
     }
 
 
-    @Before
-    public void userRegistration(){
-        // ユーザ登録
-        userRegistrationService.save(createTestUser());
-    }
-
-
     @Test
     public void login() throws Exception {
+        User testUser = createTestUser();
+        testUser.setUsername("loginTester");
+        userRegistrationService.save(testUser);
+
         this.mockMvc.perform(
                 post("/login")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("username", createTestUser().getUsername())
-                        .param("password", createTestUser().getPassword()))
+                        .param("username", testUser.getUsername())
+                        .param("password", createTestUser().getPassword())) // エンコード前のパスワードを代入
                 .andDo(print()).andExpect(status().isOk());
     }
 
 
     @Test
     public void loginFailure() throws Exception{
+        User testUser = createTestUser();
+        testUser.setUsername("loginFailureTester");
+        userRegistrationService.save(testUser);
 
         this.mockMvc.perform(
                 post("/login")

--- a/springboot/src/test/java/hello/LoginTests.java
+++ b/springboot/src/test/java/hello/LoginTests.java
@@ -1,7 +1,6 @@
 package hello;
 
 import hello.entity.User;
-import hello.service.LoginUserService;
 import hello.service.UserRegistrationService;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
## Issue番号
なし

## 実装の目的/背景
ログイン用のテストがコケていたので修正

## 概要
ログインをテストする前にユーザ登録を行うが，同じユーザを登録しようとしていたため，エラーが出ていた．

## 動作確認方法(チェック項目)
- [x] LoginTestsのテストが通る

## レビューポイント
-

## 留意事項
-

## 残課題
-

