### PR TITLE
[IR] ユーザ情報更新API（表示名）

### DIFF
--- a/springboot/src/main/java/com/asakatu/controller/UserDetailController.java
+++ b/springboot/src/main/java/com/asakatu/controller/UserDetailController.java
@@ -3,12 +3,12 @@ package com.asakatu.controller;
 import com.asakatu.OkResponse;
 import com.asakatu.entity.User;
 import com.asakatu.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
 
@@ -18,7 +18,6 @@ public class UserDetailController {
     private final
     UserRepository userRepository;
 
-
     public UserDetailController(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
@@ -26,6 +25,18 @@ public class UserDetailController {
     @GetMapping(path = "/user/{id}")
     public OkResponse userDetail(@PathVariable long id) {
         User user = userRepository.findById(id).orElseThrow();
+
+        return okUser(user);
+    }
+
+    @PutMapping(path = "/user/edit/display_name")
+    public OkResponse editUserDisplayName(@RequestParam("displayName") String displayName){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Optional<User> findUser = userRepository.findByUsername(authentication.getName());
+        User user = findUser.orElseThrow();
+
+        user.setDisplayName(displayName);
+        userRepository.save(user);
 
         return okUser(user);
     }

--- a/springboot/src/test/java/com/asakatu/UserDetailControllerTests.java
+++ b/springboot/src/test/java/com/asakatu/UserDetailControllerTests.java
@@ -6,11 +6,13 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -54,4 +56,32 @@ public class UserDetailControllerTests {
                 .andExpect(jsonPath("$.data.myself").value(true));
     }
 
+    @Test
+    @WithMockUser(username = "doiiii")
+    public void testModifyDisplayName() throws Exception{
+        this.mockMvc.perform(get("/user/2"))
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.displayName").value("ツッチー"))
+                .andExpect(jsonPath("$.data.myself").value(true));
+
+        this.mockMvc.perform(
+                put("/user/edit/display_name")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("displayName", "つっちー")
+        ).andDo(print()).andExpect(status().isOk());
+
+        this.mockMvc.perform(get("/user/2"))
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.displayName").value("つっちー"))
+                .andExpect(jsonPath("$.data.myself").value(true));
+    }
+
+    @Test
+    public void testUnauthorizedModifyDisplayName() throws Exception {
+        this.mockMvc.perform(
+                put("/user/edit/display_name")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("displayName", "つっちー")
+        ).andDo(print()).andExpect(status().isUnauthorized());
+    }
 }


### PR DESCRIPTION
## Issue番号
- fix: #62 

## 実装の目的/背景
プロフィール画面から，ユーザ情報を変更するAPI

## 概要
変更が必要なユーザ情報は以下の２つ
- 表示名
- プロフィール画像 (こちらで作業しました #105 )

ログイン済みユーザの情報を変更します．

## 動作確認方法(チェック項目)
- [x] テストがすべて通る
- [x] curlサンプルが正常に動作する

## レビューポイント
- テストの妥当性

## 留意事項
-

## 残課題
-

## curlサンプル
表示名の変更(ログイン済み)

```
curl -bcookie.txt http://localhost:8080/user/edit/display_name -XPUT -d "displayName=updatename"
```
```
{
  "data":{
    "imagePath":null,
    "displayName":"updatename",
    "username":"tester7",
    "email":"aaa@bbbb.com",
    "myself":true
  },
  "status":200
}
```

変更の確認(idはログインユーザのuserIdを指定)
```
curl -bcookie.txt http://localhost:8080/user/{id}
```
```
{
  "data":{
    "imagePath":null,
    "displayName":"updatename",
    "username":"tester7",
    "email":"aaa@bbbb.com",
    "myself":true
  },
  "status":200
}
```
上と同じ結果が表示されます




