### PR TITLE
vueからのsignup処理でCORSエラーが出るのを修正

### DIFF
--- a/springboot/src/main/java/com/asakatu/WebSecurityConfig.java
+++ b/springboot/src/main/java/com/asakatu/WebSecurityConfig.java
@@ -72,6 +72,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         corsConfiguration.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE","OPTIONS"));
         corsConfiguration.addAllowedOrigin("http://localhost:9000");
         corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.addAllowedHeader("Content-Type");
 
         UrlBasedCorsConfigurationSource corsSource = new UrlBasedCorsConfigurationSource();
         corsSource.registerCorsConfiguration("/**", corsConfiguration);

--- a/vue/src/views/SignUp.vue
+++ b/vue/src/views/SignUp.vue
@@ -12,12 +12,12 @@
                 </ul>
             </div>
             <p>
-                <label for="name">Name</label>
+                <label for="username">Name</label>
                 <input
-                        id="name"
-                        v-model="request.name"
+                        id="username"
+                        v-model="request.username"
                         type="text"
-                        name="name"
+                        name="username"
                 >
             </p>
             <p>
@@ -89,7 +89,7 @@
             checkSignUpForm: function (e) {
                 this.errors = [];
 
-                if (!this.request.name) {
+                if (!this.request.username) {
                     this.errors.push("Name required.");
                 }
                 if (!this.request.email) {
@@ -111,14 +111,21 @@
             createUser: async function () {
                 console.log("request");
                 console.log(this.request);
-                const axiosResponse = await axios.post('http://localhost:8080/user_registration', this.request, {withCredentials: true});
-                axiosResponse
-                    .then((response) => {
+                const axiosResponse = axios.post('http://localhost:8080/user_registration',
+                  JSON.stringify(this.request),
+                  {
+                    withCredentials: true,
+                    headers: {
+                      'Content-Type':'application/json'
+                    }
+                  });
+
+                axiosResponse.then(response => {
                             console.log(response);
                             alert("ok");
                         }
                     )
-                    .catch((error) => {
+                    .catch(error => {
                             console.log(error);
                             alert("Error");
                         }
@@ -132,4 +139,3 @@
     @import "../assets/css/base";
     @import "../assets/css/sign_up";
 </style>
-


### PR DESCRIPTION
## Issue番号
- fix: #121 

## 実装の目的/背景
signup処理でCORSが引っかかるのを修正

## 概要
```
const axiosResponse = axios.post('http://localhost:8080/user_registration',
                  JSON.stringify(this.request),
                  {
                    withCredentials: true,
                    headers: {
                      'Content-Type':'application/json'
                    }
                  });
```
vue側では，明示的にjsonで送ることを伝える．

```
@Bean
CorsConfigurationSource corsConfigurationSource() {
    ...
    corsConfiguration.addAllowedHeader("Content-Type");
    ...
}
```
spring側では，headerに"Content-Type"が付くことを許可する

[参考サイト](https://labor.ewigleere.net/2019/01/21/post_json_from_axios_to_php/)

## 動作確認方法(チェック項目)
- [ ]

## レビューポイント
-

## 留意事項
-

## 残課題
-

