### PR TITLE
[IR]イベント名がない修正

### DIFF
--- a/springboot/src/main/java/com/asakatu/controller/EventController.java
+++ b/springboot/src/main/java/com/asakatu/controller/EventController.java
@@ -1,18 +1,16 @@
 package com.asakatu.controller;
 
-import com.asakatu.entity.SimpleLoginUser;
+import com.asakatu.OkResponse;
+import com.asakatu.entity.Event;
 import com.asakatu.entity.User;
 import com.asakatu.entity.UserStatus;
+import com.asakatu.repository.EventRepository;
 import com.asakatu.repository.UserRepository;
 import com.asakatu.repository.UserStatusRepository;
 import com.asakatu.response.GetEventsListResponse;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import com.asakatu.OkResponse;
-import com.asakatu.entity.Event;
-import com.asakatu.repository.EventRepository;
 
 import javax.servlet.http.HttpSession;
 import java.sql.Timestamp;

--- a/springboot/src/main/java/com/asakatu/controller/EventController.java
+++ b/springboot/src/main/java/com/asakatu/controller/EventController.java
@@ -39,7 +39,7 @@ public class EventController {
 
 	@RequestMapping("/event/{eventId}")
 	public OkResponse getEvent(@PathVariable Long eventId) {
-		Event event = eventRepository.findById(eventId).get();
+		Event event = eventRepository.findById(eventId).orElseThrow();
 		return new OkResponse(new EventResponse("success", event));
 	}
 
@@ -51,7 +51,7 @@ public class EventController {
 
 	@RequestMapping("/event/{eventId}/cancel")
 	public OkResponse cancelEvent(@PathVariable Long eventId) {
-		Event cancelEvent = eventRepository.findById(eventId).get();
+		Event cancelEvent = eventRepository.findById(eventId).orElseThrow();
 		cancelEvent.setEventStatus("canceled");
 		eventRepository.save(cancelEvent);
 		return new OkResponse(new EventResponse("success", cancelEvent));
@@ -59,7 +59,8 @@ public class EventController {
 
 	@RequestMapping("/event/{eventId}/edit")
 	public OkResponse updateEvent(@RequestBody Event event, @PathVariable Long eventId) {
-		Event updateEvent = eventRepository.findById(eventId).get();
+		Event updateEvent = eventRepository.findById(eventId).orElseThrow();
+		updateEvent.setEventTitle(event.getEventTitle());
 		updateEvent.setStartDate(event.getStartDate());
 		updateEvent.setDuration(event.getDuration());
 		updateEvent.setAddress(event.getAddress());

--- a/springboot/src/main/java/com/asakatu/entity/Event.java
+++ b/springboot/src/main/java/com/asakatu/entity/Event.java
@@ -12,6 +12,9 @@ public class Event {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(name = "event_title")
+	private String eventTitle;
+
 	@Column(name = "start_date")
 	private Timestamp startDate;
 
@@ -52,9 +55,16 @@ public class Event {
 		setUpdatedAt(new Timestamp(System.currentTimeMillis()));
 	}
 
-
 	public Long getId() {
 		return id;
+	}
+
+	public String getEventTitle() {
+		return eventTitle;
+	}
+
+	public void setEventTitle(String eventTitle) {
+		this.eventTitle = eventTitle;
 	}
 
 	public void setId(Long id) {

--- a/springboot/src/main/resources/schema-product.sql
+++ b/springboot/src/main/resources/schema-product.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS user
 CREATE TABLE IF NOT EXISTS event
 (
     event_id     BIGINT(20) PRIMARY KEY AUTO_INCREMENT,
+    event_title  VARCHAR(255) NOT NULL,
     start_date   DATETIME,
     duration     DOUBLE,
     address      VARCHAR(255),

--- a/springboot/src/test/java/com/asakatu/EventControllerTests.java
+++ b/springboot/src/test/java/com/asakatu/EventControllerTests.java
@@ -70,11 +70,16 @@ public class EventControllerTests extends AbstractTest{
 		Assert.assertThat(eventsList.size(), Is.is(5));
 
 		Assert.assertThat(eventsList.get(0).getEvent().getAddress(), Is.is("東京都渋谷区1-2-3"));
+		Assert.assertThat(eventsList.get(0).getEvent().getEventTitle(), Is.is("第1回19新卒朝活"));
 		Assert.assertThat(eventsList.get(1).getEvent().getAddress(), Is.is("東京都渋谷区2-2-3"));
+		Assert.assertThat(eventsList.get(1).getEvent().getEventTitle(), Is.is("第2回19新卒朝活"));
 		Assert.assertThat(eventsList.get(2).getEvent().getAddress(), Is.is("東京都渋谷区3-2-3"));
+		Assert.assertThat(eventsList.get(2).getEvent().getEventTitle(), Is.is("第3回19新卒朝活"));
 		Assert.assertThat(eventsList.get(3).getEvent().getAddress(), Is.is("東京都渋谷区4-2-3"));
+		Assert.assertThat(eventsList.get(3).getEvent().getEventTitle(), Is.is("第4回19新卒朝活"));
 		Assert.assertThat(eventsList.get(4).getEvent().getAddress(), Is.is("東京都渋谷区5-2-3"));
-	}
+        Assert.assertThat(eventsList.get(4).getEvent().getEventTitle(), Is.is("第5回19新卒朝活"));
+    }
 
 	private UserStatus joinUserStatus() {
 		UserStatus userStatus = new UserStatus();

--- a/springboot/src/test/resources/data-product.sql
+++ b/springboot/src/test/resources/data-product.sql
@@ -11,16 +11,16 @@ VALUES ('den', 'dendo@bizreach.co.jp', 'pass4', 'でん', '/images/profile/2e3r3
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
 VALUES ('humihumi', 'ito@bizreach.co.jp', 'pass5', 'ふみき', '/images/profile/3r2jf044.jpg', FALSE);
 
-INSERT INTO event(start_date, duration, address, seat_info, event_status)
-VALUES ('2019-07-01 00:00:00', 3.0, '東京都渋谷区1-2-3', '入り口の近く', 'progress');
-INSERT INTO event(start_date, duration, address, seat_info, event_status)
-VALUES ('2019-07-02 00:00:00', 2.0, '東京都渋谷区2-2-3', '入って左', 'progress');
-INSERT INTO event(start_date, duration, address, seat_info, event_status)
-VALUES ('2019-07-03 00:00:00', 3.5, '東京都渋谷区3-2-3', '奥のソファー席', 'canceled');
-INSERT INTO event(start_date, duration, address, seat_info, event_status)
-VALUES ('2019-07-04 00:00:00', 4.0, '東京都渋谷区4-2-3', 'テラス席', 'yet');
-INSERT INTO event(start_date, duration, address, seat_info, event_status)
-VALUES ('2019-07-05 00:00:00', 1.5, '東京都渋谷区5-2-3', '鏡の前の席', 'fin');
+INSERT INTO event(event_title, start_date, duration, address, seat_info, event_status)
+VALUES ('第1回19新卒朝活', '2019-07-01 00:00:00', 3.0, '東京都渋谷区1-2-3', '入り口の近く', 'progress');
+INSERT INTO event(event_title, start_date, duration, address, seat_info, event_status)
+VALUES ('第2回19新卒朝活', '2019-07-02 00:00:00', 2.0, '東京都渋谷区2-2-3', '入って左', 'progress');
+INSERT INTO event(event_title, start_date, duration, address, seat_info, event_status)
+VALUES ('第3回19新卒朝活', '2019-07-03 00:00:00', 3.5, '東京都渋谷区3-2-3', '奥のソファー席', 'canceled');
+INSERT INTO event(event_title, start_date, duration, address, seat_info, event_status)
+VALUES ('第4回19新卒朝活', '2019-07-04 00:00:00', 4.0, '東京都渋谷区4-2-3', 'テラス席', 'yet');
+INSERT INTO event(event_title, start_date, duration, address, seat_info, event_status)
+VALUES ('第5回19新卒朝活', '2019-07-05 00:00:00', 1.5, '東京都渋谷区5-2-3', '鏡の前の席', 'fin');
 
 INSERT INTO user_event_association(user_id, event_id, event_canceled) VALUES (1, 1, FALSE);
 -- INSERT INTO user_event_association(user_id, event_id, event_canceled) VALUES (1, 1, FALSE);


### PR DESCRIPTION
## Issue番号
fix: #107 

## 実装の目的/背景
- イベント名がDBに保存されていない、イベント名を含めた設計になっていない

## 概要
- イベントテーブルにevent_titleを追加する
- イベント新規作成とイベント更新にイベント名が必要なように変更

## 動作確認方法(チェック項目)
- [x] テストデータベースの作成
```
mysql -h 127.0.0.1 -u asakatu -p asakatu < ./springboot/src/test/resources/data-product.sql
```
- [x] パスワードを変更
「kishiiii」のパスワードを「$2a$10$GiA1vRJ.c4QgrgJdPiSRG.cxn1wX/cRtkS5LAr8KwdvKbr2fMQk3e」に
- [x] イベント新規作成
```
curl -i -b cookie.txt -X POST -H "Content-Type: application/json" -d '{"eventTitle":"new title", "startDate":"2019-08-01T00:00:00.000+0000","duration":3.0,"address":"東京都渋谷区100-200","seatInfo":"入ってすぐ","eventStatus":"progress"}' -i "http://localhost:8080/event/new"
```
- [x] イベント更新
```
curl -i -b cookie.txt -X POST -H "Content-Type: application/json" -d '{"eventTitle":"update title","startDate":"2019-08-01T00:00:00.000+0000","duration":3.0,"address":"編集済み住所","seatInfo":"入ってすぐ","eventStatus":"progress"}' -i "http://localhost:8080/event/5/edit"
```

## レビューポイント
- イベント名の追加が必要な機能に抜け漏れがないか？
- APIの仕様通りに実装することができているか？

## 留意事項
- テストこれから書きます

## 残課題
- テストこれから書きます

