### PR TITLE
[IR] イベント一覧の切り替えページ

### DIFF
--- a/vue/src/components/AllEventList.vue
+++ b/vue/src/components/AllEventList.vue
@@ -1,0 +1,15 @@
+<template>
+    <div>
+        すべてのイベントリスト
+    </div>
+</template>
+
+<script>
+    export default {
+        name: "AllEventList"
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/vue/src/components/JoinedEventList.vue
+++ b/vue/src/components/JoinedEventList.vue
@@ -1,0 +1,15 @@
+<template>
+    <div id="joined-event-list">
+        参加済みのイベントリスト
+    </div>
+</template>
+
+<script>
+    export default {
+        name: "JoinedEventList"
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/vue/src/router.js
+++ b/vue/src/router.js
@@ -27,7 +27,22 @@ const router = new Router({
     {
       path: '/events',
       name: 'events',
-      component: () => import('./views/Events.vue')
+      component: () => import('./views/Events.vue'),
+      children: [
+          {
+            path: '',
+            component: () => import('./components/AllEventList.vue'),
+          },
+          {
+            path: 'all',
+            component: () => import('./components/AllEventList.vue'),
+          },
+          {
+            path: 'joined',
+            component: () => import('./components/JoinedEventList.vue'),
+          }
+        ]
+
     },
     {
       path: '/event',

--- a/vue/src/router.js
+++ b/vue/src/router.js
@@ -34,10 +34,6 @@ const router = new Router({
             component: () => import('./components/AllEventList.vue'),
           },
           {
-            path: 'all',
-            component: () => import('./components/AllEventList.vue'),
-          },
-          {
             path: 'joined',
             component: () => import('./components/JoinedEventList.vue'),
           }

--- a/vue/src/store.js
+++ b/vue/src/store.js
@@ -14,7 +14,8 @@ const loginState = new Vuex.Store({
   mutations: {
     initLogin(state) {
       state.isLogin = false;
-      state.userName = ""
+      state.userName = "";
+      state.userImagePath = "";
     },
     getActive(state, activation){
       state.isLogin = activation;

--- a/vue/src/views/Events.vue
+++ b/vue/src/views/Events.vue
@@ -1,33 +1,23 @@
 <template>
     <div id="events">
-        <p>event list</p>
-<!--    todo: 裏側の実装がまだなので後ほど。    -->
+        <div>
+            <router-link to="/events/all">すべて</router-link>|
+            <router-link to="/events/joined">参加済み</router-link>
+        </div>
+        <div>
+            <router-view/>
+        </div>
     </div>
 </template>
 
 <script>
-    import axios from 'axios'
-
     export default {
         name: "Events",
         data() {
             return {
-                eventList: {
-                    joinedEvents:[],
-                    yetEvents:[]
-                }
             }
         },
-        created: async function () {
-            await this.refresh()
-        },
         methods: {
-            refresh: async function () {
-                const res = await axios.get('http://localhost:8080/events');
-                this.eventList.joinedEvents = res.data.joined;
-                this.eventList.yetEvents = res.data.yet;
-                console.info(this.eventList);
-            },
         }
     }
 </script>

--- a/vue/src/views/Events.vue
+++ b/vue/src/views/Events.vue
@@ -1,12 +1,15 @@
 <template>
-    <div id="events">
-        <div>
-            <router-link to="/events/all">すべて</router-link>|
-            <router-link to="/events/joined">参加済み</router-link>
-        </div>
-        <div>
-            <router-view/>
-        </div>
+    <div id="events" class="event-list">
+        <section>
+            <div class="event-list-switch clearfix">
+                    <router-link to="/events" class="event-list-switch-button">ホーム</router-link>
+                    <router-link to="/events/joined" class="event-list-switch-button">参加イベント</router-link>
+            </div>
+
+            <div class="event-list-content">
+                <router-view/>
+            </div>
+        </section>
     </div>
 </template>
 
@@ -14,14 +17,44 @@
     export default {
         name: "Events",
         data() {
-            return {
-            }
+            return {}
         },
-        methods: {
-        }
+        methods: {}
     }
 </script>
 
-<style scoped lang="scss">
+<style scoped>
+    .event-list {
+        margin: 0 0;
+        height: inherit;
+        background: #f5f5f7;
+
+    }
+    .event-list-switch {
+        display: flex;
+        background-color: #ffffff;
+    }
+
+    .event-list-switch-button {
+        margin: auto;
+        color: black;
+        font-size: 14px;
+        font-weight: bold;
+        width: 30%;
+        min-width: 100px;
+        text-align: center;
+        border-bottom: white 4px solid;
+        text-decoration: none;
+    }
+
+    .router-link-exact-active {
+        border-bottom: grey 4px solid;
+    }
+
+    .event-list-content{
+        margin-top: 1rem;
+        height: max-content;
+        padding: 2em 1em 1em;
+    }
 
 </style>

--- a/vue/src/views/Login.vue
+++ b/vue/src/views/Login.vue
@@ -1,9 +1,9 @@
 <template>
     <div id="login">
-        <h2 class="login-title">login</h2>
-        <div v-if="userName">
-            <h3>{{this.userName}}</h3>
-        </div>
+<!--        <h2 class="login-title">login</h2>-->
+<!--        <div v-if="userName">-->
+<!--            <h3>{{this.userName}}</h3>-->
+<!--        </div>-->
 
         <main>
             <h2>ログイン</h2>
@@ -106,7 +106,9 @@
                         this.$store.commit('getActive', true);
                         console.log(this.$store.state.isLogin);
                         alert("ok");
-                        window.location.href = '/'
+                        this.whoami();
+                        this.$router.push('/mypage');
+                        // window.location.href = '/'
                     })
                     .catch(error => {
                         console.log("login is failed");
@@ -114,7 +116,6 @@
                         alert("please retry");
                         // this.$route.router.go('/login');
                     });
-                this.whoami();
 
             },
             whoami: function () {

--- a/vue/src/views/Login.vue
+++ b/vue/src/views/Login.vue
@@ -8,11 +8,9 @@
         <main>
             <h2>ログイン</h2>
 
-            <form action="" method="post">
-                <!--        <form-->
-                <!--                id="login-form"-->
-                <!--                @submit="checkLoginForm"-->
-                <!--        -->
+<!--            <form action="" method="post">-->
+            <form id="login-form" @submit="checkLoginForm">
+
 
                 <!-- todo:fix validation function -->
 
@@ -108,7 +106,7 @@
                         this.$store.commit('getActive', true);
                         console.log(this.$store.state.isLogin);
                         alert("ok");
-                        window.location.href = '/mypage'
+                        window.location.href = '/'
                     })
                     .catch(error => {
                         console.log("login is failed");

--- a/vue/src/views/MyPage.vue
+++ b/vue/src/views/MyPage.vue
@@ -26,7 +26,7 @@
         },
         methods:{
             //todo ここloginに持たせればいらなくなるかも
-            getUserImage:　function () {
+            getUserImage: function () {
                 const getUserInfo = axios.get('http://localhost:8080/login_user',{withCredentials:true});
                 getUserInfo.then(response=>{
                     console.log("ok");
@@ -35,7 +35,7 @@
                     const userImagePath = response.data.data.imagePath;
                     console.log("userImagePath");
                     console.log(userImagePath);
-                    this.$store.commit('getUserImage',　userImagePath);
+                    this.$store.commit('getUserImage', userImagePath);
                 })
                     .catch(error => {
                         console.error("error in get user image path");

--- a/vue/src/views/MyPage.vue
+++ b/vue/src/views/MyPage.vue
@@ -1,8 +1,8 @@
 <template>
     <section class="mypage">
         <div class="user-info">
-            <img class="user-info__image" :src="this.userInfo.userImage" alt="user image ">
-            <h2 class="user-info__name">{{this.userInfo.userName}}</h2>
+            <img class="user-info__image" :src="userImage" alt="user image ">
+            <h2 class="user-info__name" >{{userName}}</h2>
         </div>
     </section>
 </template>
@@ -13,12 +13,7 @@
     export default {
         name: "MyPage",
         data(){
-            return{
-                userInfo:{
-                    userName: this.$store.state.username,
-                    userImage: this.$store.state.userImagePath
-                }
-            }
+            return{}
         },
         created: function () {
             this.getUserImage();
@@ -40,10 +35,18 @@
                     .catch(error => {
                         console.error("error in get user image path");
                         console.error(error);
-               })
+                        this.$store.commit('initLogin');
+                        this.$router.push('/login');
+                    })
             }
         },
         computed:{
+            userName() {
+                return this.$store.state.userName;
+            },
+            userImage() {
+                return this.$store.state.userImagePath;
+            },
 
         }
     }

--- a/vue/src/views/MyPage.vue
+++ b/vue/src/views/MyPage.vue
@@ -1,8 +1,8 @@
 <template>
     <section class="mypage">
         <div class="user-info">
-            <img class="user-info__image" :src="userImage" alt="user image ">
             <h2 class="user-info__name" >{{userName}}</h2>
+            <img class="user-info__image" :src="userImage" alt="user image ">
         </div>
     </section>
 </template>


### PR DESCRIPTION
## Issue番号
- fix #143 

## 実装の目的/背景
すべてのイベントと参加イベント一覧の切り替えのため

## 概要
vue-routerに子要素を追加．
すべてのイベント一覧と参加イベント一覧用にコンポーネントを用意．
routerで切り替えるように設計．

## 動作確認方法(チェック項目)
- [ ] デザインが同じか

## レビューポイント
- コンポーネントでの切り替えで良かったのか？(引数で分岐する手法もあったかも)
- cssのあて方

## 留意事項
- #148 をマージしてます．
- デザインも含めるの難しかった．．．

## 残課題
-

## 作成物
![image](https://user-images.githubusercontent.com/50159106/64483966-a936df00-d246-11e9-9d3e-858f24bcfdfa.png)


## Xd
![image](https://user-images.githubusercontent.com/50159106/64483960-89072000-d246-11e9-8b44-690f9be213af.png)

