### PR TITLE
同じユーザが同じイベントに参加できないようにした

### DIFF
--- a/springboot/src/main/java/com/asakatu/controller/EventController.java
+++ b/springboot/src/main/java/com/asakatu/controller/EventController.java
@@ -133,13 +133,17 @@ public class EventController {
     }
 
     @PostMapping("/event/{id}/user")
-    public CreatedResponse getJoinedUser(@PathVariable long id, @RequestBody UserStatus request, HttpSession session) {
+    public CreatedResponse joinEvent(@PathVariable long id, @RequestBody UserStatus request) {
         // ログインユーザの取得
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         User user = userRepository.findUsersByUsername(authentication.getName()).get(0);
 
         // イベントの取得,設定
         Event event = eventRepository.findById(id).orElseThrow(IllegalStateException::new);
+        // 複合ユニーク制約チェック
+        if (eventRepository.findEventByIdAndUserListIn(event.getId(), user) != null) {
+            throw new IllegalArgumentException("すでにそのイベントに参加しています");
+        }
         List<User> userList = userRepository.findUsersByEventsListIn(event);
         userList.add(user);
         event.setUserList(userList);

--- a/springboot/src/main/java/com/asakatu/repository/EventRepository.java
+++ b/springboot/src/main/java/com/asakatu/repository/EventRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
     public List<Event> findEventsByUserListIn(User user);
+
+    public Event findEventByIdAndUserListIn(Long eventId, User user);
 }

--- a/springboot/src/main/resources/schema-product.sql
+++ b/springboot/src/main/resources/schema-product.sql
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS user_event_association
     event_id       BIGINT(20),
     event_canceled BOOLEAN,
     FOREIGN KEY (user_id) REFERENCES user (user_id),
-    FOREIGN KEY (event_id) REFERENCES event (event_id)
+    FOREIGN KEY (event_id) REFERENCES event (event_id),
+    UNIQUE (user_id, event_id)
 );
 
 CREATE TABLE IF NOT EXISTS user_status_master


### PR DESCRIPTION
## Issue番号
fix #125 

## 実装の目的/背景
同じユーザが同じイベントに参加できてしまうと色々不都合なため

## 概要
`user_event_association`テーブルの`user_id`と `event_id`で複合ユニーク制約をつけました

## 動作確認方法(チェック項目)
- [ ] テストデータ投入後、`INSERT INTO user_event_association(user_id, event_id, event_canceled) VALUES (1, 1, FALSE);`が
`Duplicate ...`的なメッセージが出てinsert出来ない

ユーザ登録
`curl -X POST -H "Content-Type: application/json" -d '{"username":"tester7", "password":"aabbcc2aaaaaaa", "displayName":"abc", "email":"aaa@bbbb.com", "passwordConfirm":"aabbcc2aaaaaaa"}' -i localhost:8080/user_registration`

ログイン
`curl -i -c cookie.txt -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "username=tester7" -d "password=aabbcc2aaaaaaa" "http://localhost:8080/login"`

- [ ] 初回の参加は200
`curl -i -b cookie.txt -X POST -H "Content-Type: application/json" -d '{"comment":"がんばる"}' "http://localhost:8080/event/1/user"`

- [ ] 2回目の参加は500
`curl -i -b cookie.txt -X POST -H "Content-Type: application/json" -d '{"comment":"がんばる"}' "http://localhost:8080/event/1/user"`

## レビューポイント
-

## 留意事項
-

## 残課題
-

