### PR TITLE
[IR] イベント作成ページ(vue)の側だけ作る

### DIFF
--- a/springboot/src/main/java/com/asakatu/controller/EventController.java
+++ b/springboot/src/main/java/com/asakatu/controller/EventController.java
@@ -11,6 +11,7 @@ import com.asakatu.repository.UserStatusRepository;
 import com.asakatu.response.ForFrontEvent;
 import com.asakatu.response.GetEventsListResponse;
 import com.asakatu.service.PostService;
+import org.joda.time.LocalDateTime;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -81,7 +82,7 @@ public class EventController {
 	public OkResponse createEvent(@RequestBody FromFrontEventProperties eventProperty) {
         Event event = new Event();
         event.setEventTitle(eventProperty.getEventTitle());
-        event.setStartDate(Timestamp.valueOf(eventProperty.getStartDate()));
+        event.setStartDate(eventProperty.getStartDate());
         event.setDuration(ChronoUnit.HOURS.between(eventProperty.getStartDate(), eventProperty.getEndDate()));
         event.setAddress(eventProperty.getAddress());
         event.setSeatInfo(eventProperty.getSeatInfo());

--- a/springboot/src/main/java/com/asakatu/controller/EventController.java
+++ b/springboot/src/main/java/com/asakatu/controller/EventController.java
@@ -80,6 +80,7 @@ public class EventController {
 	@RequestMapping("/event/new")
 	public OkResponse createEvent(@RequestBody FromFrontEventProperties eventProperty) {
         Event event = new Event();
+        event.setEventTitle(eventProperty.getEventTitle());
         event.setStartDate(Timestamp.valueOf(eventProperty.getStartDate()));
         event.setDuration(ChronoUnit.HOURS.between(eventProperty.getStartDate(), eventProperty.getEndDate()));
         event.setAddress(eventProperty.getAddress());

--- a/springboot/src/main/java/com/asakatu/entity/Event.java
+++ b/springboot/src/main/java/com/asakatu/entity/Event.java
@@ -2,6 +2,8 @@ package com.asakatu.entity;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Entity
@@ -16,7 +18,7 @@ public class Event {
 	private String eventTitle;
 
 	@Column(name = "start_date")
-	private Timestamp startDate;
+	private LocalDateTime startDate;
 
 	@Column(name = "duration")
 	private double duration;
@@ -71,11 +73,11 @@ public class Event {
 		this.id = id;
 	}
 
-	public Timestamp getStartDate() {
-		return startDate;
+	public LocalDateTime getStartDate() {
+		return startDate.atZone(ZoneId.of("Asia/Tokyo")).toLocalDateTime();
 	}
 
-	public void setStartDate(Timestamp startDate) {
+	public void setStartDate(LocalDateTime startDate) {
 		this.startDate = startDate;
 	}
 

--- a/springboot/src/main/java/com/asakatu/property/FromFrontEventProperties.java
+++ b/springboot/src/main/java/com/asakatu/property/FromFrontEventProperties.java
@@ -7,6 +7,8 @@ import java.time.LocalDateTime;
 @Component
 public class FromFrontEventProperties {
     // 本当はタイトルとかあるけどそのPRまだなので後から追加
+    private String eventTitle;
+
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;
@@ -14,6 +16,14 @@ public class FromFrontEventProperties {
     private String address;
 
     private String seatInfo;
+
+    public String getEventTitle() {
+        return eventTitle;
+    }
+
+    public void setEventTitle(String eventTitle) {
+        this.eventTitle = eventTitle;
+    }
 
     public LocalDateTime getStartDate() {
         return startDate;

--- a/springboot/src/main/java/com/asakatu/service/PostService.java
+++ b/springboot/src/main/java/com/asakatu/service/PostService.java
@@ -10,14 +10,13 @@ import java.util.Locale;
 
 @Service
 public class PostService{
-    public String getDesignDate(Timestamp startDate, double duration) {
+    public String getDesignDate(LocalDateTime startDate, double duration) {
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("[]H:mm");
 
-        LocalDateTime startLocalDate = startDate.toLocalDateTime();
-        LocalDateTime endLocalDate = startLocalDate.plusHours((long) duration);
-        String dayOfWeek = startLocalDate.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.JAPANESE);
+        LocalDateTime endLocalDate = startDate.plusHours((long) duration);
+        String dayOfWeek = startDate.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.JAPANESE);
         return dayOfWeek + " "
-                + dateFormat.format(startLocalDate)
+                + dateFormat.format(startDate)
                 + " 〜 "
                 + dateFormat.format(endLocalDate);
     }

--- a/vue/src/views/EventCreate.vue
+++ b/vue/src/views/EventCreate.vue
@@ -12,30 +12,30 @@
                 </ul>
             </div>
             <p>
-                <label for="name">event Name</label>
+                <label for="name">event title</label>
                 <input
                         id="name"
-                        v-model="request.eventName"
+                        v-model="request.eventTitle"
                         type="text"
                         name="name"
                 >
             </p>
             <p>
-                <label for="date">startDate</label>
+                <label for="startDate">start date</label>
                 <input
-                        id="date"
+                        id="startDate"
                         v-model="request.startDate"
                         type="datetime-local"
-                        name="date"
+                        name="startDate"
                 >
             </p>
             <p>
-                <label for="duration">duration</label>
+                <label for="endDate">end date</label>
                 <input
-                        id="duration"
-                        v-model="request.duration"
-                        type="number"
-                        name="duration"
+                        id="endDate"
+                        v-model="request.endDate"
+                        type="datetime-local"
+                        name="endDate"
                 >
             </p>
             <p>
@@ -45,6 +45,15 @@
                         v-model="request.address"
                         type="text"
                         name="address"
+                >
+            </p>
+            <p>
+                <label for="seatInfo">seat info</label>
+                <input
+                        id="seatInfo"
+                        v-model="request.seatInfo"
+                        type="text"
+                        name="seatInfo"
                 >
             </p>
             <p>
@@ -71,15 +80,14 @@
 <script>
 
     import axios from 'axios';
-
     export default {
         name: "EventCreate",
         data() {
             return {
                 request: {
-                    eventName: "",
+                    eventTitle: "",
                     startDate: "",
-                    duration: 0,
+                    endDate: "",
                     address: "",
                     seatInfo: "",
                     eventDetail: ""
@@ -90,7 +98,7 @@
         methods: {
             checkEventCreateForm: function (e) {
                 this.errors = [];
-                if (!this.request.eventName) {
+                if (!this.request.eventTitle) {
                     this.errors.push("Name required.");
                 }
                 if (!this.request.startDate) {

--- a/vue/src/views/EventCreate.vue
+++ b/vue/src/views/EventCreate.vue
@@ -25,8 +25,17 @@
                 <input
                         id="startDate"
                         v-model="request.startDate"
-                        type="datetime-local"
+                        type="date"
                         name="startDate"
+                >
+            </p>
+            <p>
+                <label for="startDate">start time</label>
+                <input
+                        id="startTime"
+                        v-model="startTime"
+                        type="time"
+                        name="startTime"
                 >
             </p>
             <p>
@@ -34,8 +43,17 @@
                 <input
                         id="endDate"
                         v-model="request.endDate"
-                        type="datetime-local"
+                        type="date"
                         name="endDate"
+                >
+            </p>
+            <p>
+                <label for="endTime">end time</label>
+                <input
+                        id="endTime"
+                        v-model="endTime"
+                        type="time"
+                        name="endTime"
                 >
             </p>
             <p>
@@ -63,7 +81,7 @@
                         id="eventDetail"
                         cols="30"
                         rows="10"
-                        v-model="request.eventDetail"
+                        v-model="eventDetail"
                         placeholder="add event details"
                 >
             </textarea>
@@ -90,8 +108,10 @@
                     endDate: "",
                     address: "",
                     seatInfo: "",
-                    eventDetail: ""
                 },
+                startTime: "",
+                endTime: "",
+                eventDetail: "",
                 errors: [],
             }
         },
@@ -104,6 +124,11 @@
                 if (!this.request.startDate) {
                     this.errors.push('start date required.');
                 }
+                console.log(this.startTime);
+
+                this.request.startDate += "T" + this.startTime;
+                this.request.endDate += "T" + this.endTime;
+
                 if (!this.errors.length) {
                     this.createEvent();
                     e.preventDefault();

--- a/vue/src/views/EventCreate.vue
+++ b/vue/src/views/EventCreate.vue
@@ -132,7 +132,6 @@
                 if (!this.errors.length) {
                     this.createEvent();
                     e.preventDefault();
-                    return true;
                 }
                 e.preventDefault();
             },
@@ -142,9 +141,12 @@
                 if (axiosResponse.status === 200 || axiosResponse.status === 201) {
                     console.log("ok");
                     console.log(axiosResponse);
+                    this.$router.push('/events');
                 } else {
                     console.log("error");
                     console.log(axiosResponse);
+                    this.$store.commit('initLogin');
+                    this.$router.push('/login');
                 }
             }
         }


### PR DESCRIPTION
## Issue番号
- fix: #142 

## 実装の目的/背景
イベント作成ページのデザインがまだなので，デザインが出来上がり次第対応できるようにAPIとformを用意する．

## 概要
イベント作成時に必要な情報をformで用意

## 動作確認方法(チェック項目)
- [x] `http://localhost:9000/#/event/create`にアクセス
- [x] 必要事項を記入しsubmit
- [x] eventlistページに遷移される．
- [x] イベントデータが見えるUIがないので，DBの中身orAPIを叩いてね

## レビューポイント
- formを日付と日時で分けたことについて
- タイムゾーンの指定方法について

## 留意事項
-

## 残課題
-

## 作成物
![image](https://user-images.githubusercontent.com/50159106/64530584-783ed300-d348-11e9-9e6e-600406f0e150.png)

