### PR TITLE
data-product.sqlのpasswordをハッシュ化後にして動作確認するときユーザ作成しなくても良いようにした

### DIFF
--- a/springboot/src/test/resources/data-product.sql
+++ b/springboot/src/test/resources/data-product.sql
@@ -1,15 +1,15 @@
 -- TODO 2019/07/06 Controllerテストのために作成、後で消す？ jojo
 
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('kishiiii', 'kishida@bizreach.co.jp', 'pass1', 'きしー', '/images/profile/2u1e0h30x38.jpg', FALSE);
+VALUES ('kishiiii', 'kishida@bizreach.co.jp', '$2a$10$W8UjL5w3LzP6yN1h/SM3qOjekYSjWJ8FsGhDaeBIx4/gGzTrdKwCm', 'きしー', '/images/profile/2u1e0h30x38.jpg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('doiiii', 'doi@bizreach.co.jp', 'pass2', 'ツッチー', '/images/profile/ewp3rf33r.jpg', FALSE);
+VALUES ('doiiii', 'doi@bizreach.co.jp', '$2a$10$LbFHB5TDQNNgQwk1paCzZe0AaKUnLKHxCnJzR1RgcCBfGgIHDXUkW', 'ツッチー', '/images/profile/ewp3rf33r.jpg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('koma', 'komatsu@bizreach.co.jp', 'pass3', 'こまっち', '/images/profile/fwep3r3rf.jpg', FALSE);
+VALUES ('koma', 'komatsu@bizreach.co.jp', '$2a$10$uf68qeoq2jfM/NG8nyvx0.PZbt8ZLXLKJuyYUxl7hQRR2EpXxDvVy', 'こまっち', '/images/profile/fwep3r3rf.jpg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('den', 'dendo@bizreach.co.jp', 'pass4', 'でん', '/images/profile/2e3r3jorqwe3.jpg', FALSE);
+VALUES ('den', 'dendo@bizreach.co.jp', '$2a$10$/HIeHqT1KeKStPs4bqz.Ge3IiNF8TVaBtZbUP1qJHYKBMqqPpFU3m', 'でん', '/images/profile/2e3r3jorqwe3.jpg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('humihumi', 'ito@bizreach.co.jp', 'pass5', 'ふみき', '/images/profile/3r2jf044.jpg', FALSE);
+VALUES ('humihumi', 'ito@bizreach.co.jp', '$2a$10$pPFilOCPLuMPSMZ4PrTGoutQs9dSONS2X2wRl4S3Q7I8MnYm9tItK', 'ふみき', '/images/profile/3r2jf044.jpg', FALSE);
 
 INSERT INTO event(event_title, start_date, duration, address, seat_info, event_status)
 VALUES ('第1回19新卒朝活', '2019-07-01 00:00:00', 3.0, '東京都渋谷区1-2-3', '入り口の近く', 'progress');


### PR DESCRIPTION
## Issue番号
fix #155 

## 実装の目的/背景
動作確認らくかなって、というかユーザ作っておいてもログイン出来ないんじゃ悲しいしね

## 概要

## 動作確認方法(チェック項目)
一度DBまっさらにしてアプリケーション起動
- [ ] 今まで通りテストデータを流す
```
mysql -h 127.0.0.1 -u asakatu -p asakatu < ./springboot/src/test/resources/data-product.sql
```
- [ ] 以下で200が返ってきてログインできることを確認
```
curl -i -c cookie.txt -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "username=kishiiii" -d "password=password1" "http://localhost:8080/login"
```

## レビューポイント
-

## 留意事項
-

## 残課題
-

