### PR TITLE
fix: data-product.sql のimage_pathをアクセス可能な画像にした

### DIFF
--- a/springboot/src/test/java/com/asakatu/EventControllerTests.java
+++ b/springboot/src/test/java/com/asakatu/EventControllerTests.java
@@ -165,7 +165,7 @@ public class EventControllerTests extends AbstractTest{
                 .andExpect(jsonPath("$.data.userList",hasSize(4)))
                 .andExpect(jsonPath("$.data.userList[0].id").value(1))
                 .andExpect(jsonPath("$.data.userList[0].displayName").value("きしー"))
-                .andExpect(jsonPath("$.data.userList[0].imagePath").value("/images/profile/2u1e0h30x38.jpg"));
+                .andExpect(jsonPath("$.data.userList[0].imagePath").value("https://user-images.githubusercontent.com/18584908/69044408-36ad6100-0a38-11ea-9e36-604b6c344b2a.jpeg"));
     }
 }
 

--- a/springboot/src/test/resources/data-product.sql
+++ b/springboot/src/test/resources/data-product.sql
@@ -1,15 +1,15 @@
 -- TODO 2019/07/06 Controllerテストのために作成、後で消す？ jojo
 
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('kishiiii', 'kishida@bizreach.co.jp', '$2a$10$W8UjL5w3LzP6yN1h/SM3qOjekYSjWJ8FsGhDaeBIx4/gGzTrdKwCm', 'きしー', '/images/profile/2u1e0h30x38.jpg', FALSE);
+VALUES ('kishiiii', 'kishida@bizreach.co.jp', '$2a$10$W8UjL5w3LzP6yN1h/SM3qOjekYSjWJ8FsGhDaeBIx4/gGzTrdKwCm', 'きしー', 'https://user-images.githubusercontent.com/18584908/69044408-36ad6100-0a38-11ea-9e36-604b6c344b2a.jpeg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('doiiii', 'doi@bizreach.co.jp', '$2a$10$LbFHB5TDQNNgQwk1paCzZe0AaKUnLKHxCnJzR1RgcCBfGgIHDXUkW', 'ツッチー', '/images/profile/ewp3rf33r.jpg', FALSE);
+VALUES ('doiiii', 'doi@bizreach.co.jp', '$2a$10$LbFHB5TDQNNgQwk1paCzZe0AaKUnLKHxCnJzR1RgcCBfGgIHDXUkW', 'ツッチー', 'https://user-images.githubusercontent.com/18584908/69044436-47f66d80-0a38-11ea-91be-e0d5c4565ac5.jpeg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('koma', 'komatsu@bizreach.co.jp', '$2a$10$uf68qeoq2jfM/NG8nyvx0.PZbt8ZLXLKJuyYUxl7hQRR2EpXxDvVy', 'こまっち', '/images/profile/fwep3r3rf.jpg', FALSE);
+VALUES ('koma', 'komatsu@bizreach.co.jp', '$2a$10$uf68qeoq2jfM/NG8nyvx0.PZbt8ZLXLKJuyYUxl7hQRR2EpXxDvVy', 'こまっち', 'https://user-images.githubusercontent.com/18584908/69044459-52186c00-0a38-11ea-9dec-d51a4e429137.jpeg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('den', 'dendo@bizreach.co.jp', '$2a$10$/HIeHqT1KeKStPs4bqz.Ge3IiNF8TVaBtZbUP1qJHYKBMqqPpFU3m', 'でん', '/images/profile/2e3r3jorqwe3.jpg', FALSE);
+VALUES ('den', 'dendo@bizreach.co.jp', '$2a$10$/HIeHqT1KeKStPs4bqz.Ge3IiNF8TVaBtZbUP1qJHYKBMqqPpFU3m', 'でん', 'https://user-images.githubusercontent.com/18584908/69044486-593f7a00-0a38-11ea-97ee-493939615259.jpeg', FALSE);
 INSERT INTO user(username, email, password, display_name, image_path, created_event)
-VALUES ('humihumi', 'ito@bizreach.co.jp', '$2a$10$pPFilOCPLuMPSMZ4PrTGoutQs9dSONS2X2wRl4S3Q7I8MnYm9tItK', 'ふみき', '/images/profile/3r2jf044.jpg', FALSE);
+VALUES ('humihumi', 'ito@bizreach.co.jp', '$2a$10$pPFilOCPLuMPSMZ4PrTGoutQs9dSONS2X2wRl4S3Q7I8MnYm9tItK', 'ふみき', 'https://user-images.githubusercontent.com/18584908/69044500-5fcdf180-0a38-11ea-85bf-b87f3705f231.jpeg', FALSE);
 
 INSERT INTO event(event_title, event_detail, start_date, duration, address, store_name, seat_info, event_status)
 VALUES ('第1回19新卒朝活', '第1回19新卒朝活詳細です！', '2019-07-01 00:00:00', 3.0, '東京都渋谷区1-2-3', '朝活カフェ1', '入り口の近く', 'progress');


### PR DESCRIPTION
## Issue番号
fix: #200 

## 実装の目的/背景
デザイン作る上で流石にないとめんどくさそうなので

## 概要

## 動作確認方法(チェック項目)
- [ ] mysql一回`down`させて`up`して`spring run`して
```
mysql -h 127.0.0.1 -u asakatu -p asakatu < ./springboot/src/test/resources/data-product.sql
```
して用意されているユーザでログインして画像が表示されているか

## レビューポイント
-

## 留意事項
-

## 残課題
-

