### PR TITLE
ユーザーステータス詳細画面の実装

### DIFF
--- a/vue/src/api/event.js
+++ b/vue/src/api/event.js
@@ -18,8 +18,10 @@ const EventService = {
     },
     contract(eventId, request) {
         return ApiService.post('/event/' + eventId + '/user', request)
+    },
+    getUserReaction(eventId, userId){
+     return ApiService.get('/event/' + eventId + '/user' + userId)
     }
-
 };
 
 export default EventService;

--- a/vue/src/components/eventDetail/UserReactionDetail.vue
+++ b/vue/src/components/eventDetail/UserReactionDetail.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="reaction-detail">
+        <img :src="imagePath" alt="">
+        <h3 class="name">{{displayName}}</h3>
+        <div class="status">{{content}}</div>
+        <p class="comment">{{comment}}</p>
+    </div>
+</template>
+
+<script>
+    export default {
+        name: "UserReactionDetail",
+        props:{
+            eventId: Number,
+            userId: Number
+        },
+        data(){
+            return {
+                displayName : String,
+                imagePath : String,
+                content : String,
+                comment : String
+            }
+        },
+        methods:{
+            // GET /event/{eventId}/user/{userId}
+            // レスポンスめも
+            //"statusId": 1,
+            // "userName": "asakatu-kun",
+            // "displayName": "朝活くん",
+            // "imagePath": "https://avatars0.githubusercontent.com/u/50159106",
+            // "content": "https://4.bp.blogspot.com/-m56DCo_VDbQ/UU--ubQ1vTI/AAAAAAAAO84/CWFZIAw-zxY/s1600/kaizoku_mark.png",
+            // "comment": "おしゃべりしたい！"
+        }
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/vue/src/components/eventDetail/UserReactionDetail.vue
+++ b/vue/src/components/eventDetail/UserReactionDetail.vue
@@ -8,6 +8,9 @@
 </template>
 
 <script>
+
+    import event from "../../../api/event"
+
     export default {
         name: "UserReactionDetail",
         props:{
@@ -23,14 +26,18 @@
             }
         },
         methods:{
-            // GET /event/{eventId}/user/{userId}
-            // レスポンスめも
-            //"statusId": 1,
-            // "userName": "asakatu-kun",
-            // "displayName": "朝活くん",
-            // "imagePath": "https://avatars0.githubusercontent.com/u/50159106",
-            // "content": "https://4.bp.blogspot.com/-m56DCo_VDbQ/UU--ubQ1vTI/AAAAAAAAO84/CWFZIAw-zxY/s1600/kaizoku_mark.png",
-            // "comment": "おしゃべりしたい！"
+            getUserReaction:function (eventId, userId) {
+                event.getUserReaction(eventId,userId)
+                    .then( data =>{
+                        this.displayName = data.data.displayName;
+                        this.imagePath = data.data.imagePath;
+                        this.content = data.data.content;
+                        this.comment = data.data.comment;
+                    })
+                    .catch(()=>{
+                        alert('something is error, please retry later');
+                    })
+            }
         }
     }
 </script>


### PR DESCRIPTION
## Issue番号
#194 作り直した

## 実装の目的/背景
参加中かつ開催中のイベントで、他のユーザーのステータス詳細を見ることができる。

## 概要
画面はよくわからないけど、動きだけ作る。
- ユーザーの画像
- ユーザーの名前
- ユーザーのステータス
- 一言

表示するだけ。
編集する必要はない。

## 動作確認方法(チェック項目)
- [ ] 

## レビューポイント
-

## 留意事項
-

## 残課題
- `/api` をせっかく用意したのにつかってないところたくさんあるので修正したい

