### PR TITLE
[IR] リアクションリスト無限増殖問題の解決

### DIFF
--- a/springboot/src/main/resources/schema-product.sql
+++ b/springboot/src/main/resources/schema-product.sql
@@ -1,10 +1,9 @@
-
 CREATE TABLE IF NOT EXISTS user
 (
     user_id       BIGINT(20) PRIMARY KEY AUTO_INCREMENT,
     username      VARCHAR(50)  NOT NULL UNIQUE,
     email         VARCHAR(255) NOT NULL,
-    password      VARCHAR(255)  NOT NULL,
+    password      VARCHAR(255) NOT NULL,
     display_name  VARCHAR(50)  NOT NULL,
     image_path    VARCHAR(255),
     created_event BOOLEAN,
@@ -23,8 +22,8 @@ CREATE TABLE IF NOT EXISTS event
     store_name   VARCHAR(255),
     seat_info    VARCHAR(255),
     event_status ENUM ('yet', 'fin', 'canceled', 'progress'),
-    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS user_event_association
@@ -78,7 +77,18 @@ CREATE TABLE IF NOT EXISTS user_group_association
     FOREIGN KEY (user_group_id) REFERENCES user_group (user_group_id)
 );
 
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-meh');
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-grin-squint-tears');
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-smile');
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-dizzy');
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (1, 'far fa-meh')
+ON DUPLICATE KEY UPDATE user_status_master_id=1;
+
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (2, 'far fa-grin-squint-tears')
+ON DUPLICATE KEY UPDATE user_status_master_id=2;
+
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (3, 'far fa-smile')
+ON DUPLICATE KEY UPDATE user_status_master_id=3;
+
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (4, 'far fa-dizzy')
+ON DUPLICATE KEY UPDATE user_status_master_id=4;


### PR DESCRIPTION
## Issue番号
- fix: #175 

## 実装の目的/背景
リアクションリスト無限増殖問題の解決

## 概要
Springを再起動する度に、auto increment が働いて、選択するリアクションが増えていました。

## 動作確認方法(チェック項目)
- [ ] springを二回起動してuser_status_masterテーブルの内容が重複しない

## レビューポイント
-

## 留意事項
-

## 残課題
-

