### PR TITLE
[WIP] イベント詳細ページにリアクション変更機能を追加する

### DIFF
--- a/springboot/src/main/resources/schema-product.sql
+++ b/springboot/src/main/resources/schema-product.sql
@@ -1,10 +1,9 @@
-
 CREATE TABLE IF NOT EXISTS user
 (
     user_id       BIGINT(20) PRIMARY KEY AUTO_INCREMENT,
     username      VARCHAR(50)  NOT NULL UNIQUE,
     email         VARCHAR(255) NOT NULL,
-    password      VARCHAR(255)  NOT NULL,
+    password      VARCHAR(255) NOT NULL,
     display_name  VARCHAR(50)  NOT NULL,
     image_path    VARCHAR(255),
     created_event BOOLEAN,
@@ -23,8 +22,8 @@ CREATE TABLE IF NOT EXISTS event
     store_name   VARCHAR(255),
     seat_info    VARCHAR(255),
     event_status ENUM ('yet', 'fin', 'canceled', 'progress'),
-    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS user_event_association
@@ -78,7 +77,18 @@ CREATE TABLE IF NOT EXISTS user_group_association
     FOREIGN KEY (user_group_id) REFERENCES user_group (user_group_id)
 );
 
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-meh');
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-grin-squint-tears');
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-smile');
-INSERT INTO user_status_master(user_status_content) VALUES ('far fa-dizzy');
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (1, 'far fa-meh')
+ON DUPLICATE KEY UPDATE user_status_master_id=1;
+
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (2, 'far fa-grin-squint-tears')
+ON DUPLICATE KEY UPDATE user_status_master_id=2;
+
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (3, 'far fa-smile')
+ON DUPLICATE KEY UPDATE user_status_master_id=3;
+
+INSERT INTO user_status_master(user_status_master_id, user_status_content)
+VALUES (4, 'far fa-dizzy')
+ON DUPLICATE KEY UPDATE user_status_master_id=4;

--- a/vue/src/components/eventDetail/UserReaction.vue
+++ b/vue/src/components/eventDetail/UserReaction.vue
@@ -1,18 +1,27 @@
 <template>
     <div id="demo-user-reaction">
-        <i v-bind:class="myReaction.userStatusContent"></i>
-        |
-        <span v-for="reaction in reactionList" v-bind:key=reaction.id>
-            <input type="radio" v-bind:id="reaction.id" v-model="checked" v-bind:value="reaction.id" style="display:none">
-            <label v-bind:for="reaction.id">
-                <i v-bind:class="reaction.userStatusContent"></i>
-            </label>
+        <span>
+            <img :src="userImage" v-bind:alt="userName" class="participant-image image_circle">
+        </span>
+
+        <span class="participant-myreaction-balloon">
+            <i v-bind:class="myReaction.userStatusContent" class="participant-myreaction"></i>
+        </span>
+
+        <span class="reaction-change">
+            <span v-for="reaction in reactionList" v-bind:key=reaction.id>
+                <input type="radio" v-bind:id="reaction.id" v-model="checked" v-bind:value="reaction.id" style="display:none">
+                <label v-bind:for="reaction.id" class="participant-reaction-balloon1">
+                    <i v-bind:class="reaction.userStatusContent" class="participant-reaction"></i>
+                </label>
+            </span>
         </span>
     </div>
 </template>
 
 <script>
     import axios from 'axios'
+    import {mapState} from 'vuex'
 
     export default {
         name: "demo-user-reaction",
@@ -20,7 +29,6 @@
         data() {
             return {
                 reactionList: [],
-                userName: this.$store.state.userName,
                 myReaction: "",
                 checked: ""
             }
@@ -64,6 +72,162 @@
           this.getReactionList();
           this.getMyReaction();
 
+        },
+        computed: {
+            ...mapState({
+                userName: state => state.userInfo.userName,
+                userImage: state => state.userInfo.userImagePath
+            }),
         }
     }
 </script>
+
+<style scoped lang="scss">
+
+.participant{
+    &-list{
+        margin: 0 auto;
+        display: flex;
+        &:first-child{
+        }
+    }
+    &-image{
+        width: 15vw;
+        height: 15vw;
+        margin-right: 1vw;
+        margin-left: 1vw;
+        margin-top: 2vh;
+    }
+    &-reaction {
+        margin: auto;
+
+        &-balloon1 {
+            // position: relative;
+            display: inline-block;
+            margin: 0 2px;
+            padding: 10px 5px;
+            min-width: 10%;
+            max-width: 100%;
+            color: #555;
+            background: #FFDE95;
+            border-radius: 10px;
+            text-align: center;
+        }
+
+        &-balloon1:before {
+            content: "";
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            margin-left: -5px;
+            border: 5px solid transparent;
+            border-top: 8px solid #FFDE95;
+        }
+
+        &-balloon1 p {
+            margin: 0;
+            padding: 0;
+        }
+    }
+
+    &-myreaction {
+        margin: auto;
+
+        &-balloon {
+            position: relative;
+            display: inline-block;
+            margin: auto;
+            padding: 10px 5px;
+            min-width: 10%;
+            max-width: 100%;
+            color: #555;
+            background: #FFDE95;
+            border-radius: 10px;
+            text-align: center;
+        }
+
+        /* アイコンを左に表示 */
+        &-balloon::before{
+            content: '';
+            position: absolute;
+            display: block;
+            width: 0;
+            height: 0;
+            left: -7px;
+            top: 7px;
+            border-right: 8px solid #FFDE95;
+            border-top: 6px solid transparent;
+            border-bottom: 6px solid transparent;
+        }
+    }
+
+    &-label{
+        width: auto;
+    }
+
+    &-modal{
+        &__btn{
+            background-color: #FFB100;
+            border-radius: 22px;
+            border-color: white;
+            width: 30vw;
+            height: 5vh;
+            color: white;
+
+            &-cancel{
+                font-size: small;
+                color: #08c;
+                margin-top: 10px;
+            }
+        }
+
+        &-body{
+            height: inherit;
+        }
+
+        &-textlines{
+            border: 1px solid #707070;  /* 枠線 */
+            border-radius: 8px;         /* 角丸 */
+            padding: 5%;              /* 内側の余白量 */
+            width: 90%;           /* 横幅 */
+            height: 100%;              /* 高さ */
+            font-size: 1em;             /* 文字サイズ */
+            line-height: 1.2;           /* 行の高さ */
+            resize: none;
+        }
+
+        &-detail{
+            color: #707070;
+            font-size: 13px;
+            text-align: left;
+            margin-bottom: 20px;
+        }
+
+        &-contract{
+            font-size: 23px;
+            text-align: left;
+        }
+
+        &-link{
+            padding-top: 20px;
+        }
+
+        &-space{
+            height: 120px;
+            visibility: hidden;
+        }
+    }
+
+    &-element{
+        display: grid;
+    }
+}
+
+.reaction{
+    &-change{
+        margin-left: 10px;
+        padding: 15px;
+        border: 2px black solid;
+    }
+}
+</style>

--- a/vue/src/views/Event.vue
+++ b/vue/src/views/Event.vue
@@ -70,9 +70,7 @@
               </div>
           </modal-template>
 
-          <section v-if="this.hasJoin" class="reaction-change">
-              ここでリアクション変更
-          </section>
+          <user-reaction v-if="this.hasJoin" v-bind:eventId="eventId"/>
 
           <section class="event-participant section-margin">
               <h3 class="participant-title">参加メンバー</h3>
@@ -108,13 +106,14 @@
     import ModalTemplate from "../components/eventDetail/ModalTemplate";
     import event from "../api/event";
     import Header from '@/components/common/Header.vue';
+    import UserReaction from "@/components/eventDetail/UserReaction";
 
     export default {
         name: "Event",
         components: {
             ModalTemplate,
-            Header
-
+            Header,
+            UserReaction
         },
         template: '<modal-template></modal-template>',
         data() {


### PR DESCRIPTION
## Issue番号
- fix: #151 

## 実装の目的/背景
イベント詳細ページにリアクション変更機能を追加する

## 概要
リアクション変更機能は、コンポーネントで用意している

## 動作確認方法(チェック項目)
- [ ]

## レビューポイント
-

## 留意事項
- #209 をマージしてから作業しています。

## 残課題
- 参加ユーザ一覧に表示されているリアクションが変更されない。
- デザイン　(現在は動くところまで実装しただけ)

