### PR TITLE
[IR]複数日に渡るイベントを登録できないように変更

### DIFF
--- a/vue/src/views/EventCreate.vue
+++ b/vue/src/views/EventCreate.vue
@@ -26,7 +26,7 @@
                   </label>
               </p>
               <p class="form__start">
-                  <label for="startDate"> 開始日時
+                  <label for="startDate"> 開催日
                     <div class="event-create-form--twoColumn">
                       <input
                               id="startDate"
@@ -34,25 +34,26 @@
                               type="date"
                               name="startDate"
                       >
-                      <input
-                              id="startTime"
-                              v-model="startTime"
-                              type="time"
-                              name="startTime"
-                      >
                     </div>
 
                   </label>
               </p>
               <p>
-                  <label for="endDate">終了日時
+                  <label>イベント時間
                     <div class="event-create-form--twoColumn">
-                      <input
+                      <!-- <input
                                 id="endDate"
                                 v-model="request.endDate"
                                 type="date"
                                 name="endDate"
+                        > -->
+                        <input
+                                id="startTime"
+                                v-model="startTime"
+                                type="time"
+                                name="startTime"
                         >
+                        <span class="duration">~</span>
                         <input
                                 id="endTime"
                                 v-model="endTime"
@@ -62,19 +63,8 @@
                       </div>
                       </label>
               </p>
-
               <p>
-                  <label for="address">開催住所
-                  <input
-                          id="address"
-                          v-model="request.address"
-                          type="text"
-                          name="address"
-                  >
-                  </label>
-              </p>
-              <p>
-                  <label for="storeName">店名
+                  <label for="storeName">開催場所名
                   <input
                           id="storeName"
                           v-model="request.storeName"
@@ -84,7 +74,17 @@
                   </label>
               </p>
               <p>
-                  <label for="seatInfo">開催場所のどこらへんに集合するか
+                  <label for="address">開催場所の住所
+                  <input
+                          id="address"
+                          v-model="request.address"
+                          type="text"
+                          name="address"
+                  >
+                  </label>
+              </p>
+              <p>
+                  <label for="seatInfo">開催場所内での集合位置
                   <input
                           id="seatInfo"
                           v-model="request.seatInfo"
@@ -221,10 +221,14 @@
         &--twoColumn {
           display: flex;
           > input {
-            width: 40%;
+            width: 35%;
             & + input {
               margin-left: 5%;
             }
+          }
+          .duration {
+            font-size: 1.5rem;
+            line-height: 3rem;
           }
         }
       }

--- a/vue/src/views/EventCreate.vue
+++ b/vue/src/views/EventCreate.vue
@@ -25,7 +25,7 @@
                   >
                   </label>
               </p>
-              <p class="form__start">
+              <p>
                   <label for="startDate"> 開催日
                     <div class="event-create-form--twoColumn">
                       <input


### PR DESCRIPTION
## Issue番号

## 実装の目的/背景
As-Is：複数日に渡るイベントが作成できるようになっていた
問題点：複数日に渡るイベントは開催できるべきではない。
To-Be：複数日に渡るイベントを作成できないようにする

## 概要
As-Is
項目 | 項目の内容
開始日時 | 日付、時間
終了日時 | 日付、時間

To-Be
項目 | 項目の内容
開催日 | 日付
イベント時間 | 時間*2

## 動作確認方法(チェック項目)
- [ ] 概要のように表示が変更されていること

## レビューポイント
- 

## 留意事項
- 

## 残課題
- 開催日の項目について、id名が実態とあっていない。idを変更する場合、フォームとしてのロジックの部分も変更する必要がある？
- フォームとしてのロジックを変更する必要があるのであれば、こまっちゃんに該当部分をお願いしたい。
- 提案したいid名としては、holdingDate かな

